### PR TITLE
I got tired of scrolling through counter messages..

### DIFF
--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/GenerateNarrativesTask.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/GenerateNarrativesTask.java
@@ -59,6 +59,7 @@ import org.onebusaway.transit_data_federation.services.transit_graph.StopEntry;
 import org.onebusaway.transit_data_federation.services.transit_graph.StopTimeEntry;
 import org.onebusaway.transit_data_federation.services.transit_graph.TransitGraphDao;
 import org.onebusaway.transit_data_federation.services.transit_graph.TripEntry;
+import org.onebusaway.transit_data_federation.util.LoggingIntervalUtil;
 import org.onebusaway.utility.ObjectSerializationLibrary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,6 +99,8 @@ public class GenerateNarrativesTask implements Runnable {
   private RefreshService _refreshService;
 
   private double _stopDirectionStandardDeviationThreshold = 0.7;
+  
+  private LoggingIntervalUtil _logIntervals = new LoggingIntervalUtil();
 
   @Autowired
   public void setBundle(FederatedTransitDataBundle bundle) {
@@ -212,11 +215,13 @@ public class GenerateNarrativesTask implements Runnable {
   public void generateShapePointNarratives(NarrativeProviderImpl provider) {
 
     List<AgencyAndId> shapeIds = _gtfsDao.getAllShapeIds();
-    _log.info("shapes to process=" + shapeIds.size());
+    int shapeSize = shapeIds.size();
+    _log.info("shapes to process=" + shapeSize);
+    int logInterval = _logIntervals.getAppropriateLoggingInterval(shapeSize) * 10;
     int index = 0;
 
     for (AgencyAndId shapeId : shapeIds) {
-      if (index % 10 == 0)
+      if (index % logInterval == 0)
         _log.info("shapes=" + index);
       index++;
       ShapePoints shapePoints = _shapePointsHelper.getShapePointsForShapeId(shapeId);
@@ -232,10 +237,11 @@ public class GenerateNarrativesTask implements Runnable {
 
     Collection<Stop> allStops = _gtfsDao.getAllStops();
     Map<AgencyAndId, Stop> stopsById = MappingLibrary.mapToValue(allStops, "id");
+    int logInterval = _logIntervals.getAppropriateLoggingInterval(allStops.size());
 
     for (StopEntry stopEntry : _transitGraphDao.getAllStops()) {
 
-      if (index % 10 == 0)
+      if (index % logInterval == 0)
         _log.info("stops=" + index);
       index++;
 
@@ -259,10 +265,11 @@ public class GenerateNarrativesTask implements Runnable {
 
     int tripIndex = 0;
     Collection<Trip> trips = _gtfsDao.getAllTrips();
+    int logInterval = _logIntervals.getAppropriateLoggingInterval(trips.size());
 
     for (Trip trip : trips) {
 
-      if (tripIndex % 200 == 0) {
+      if (tripIndex % logInterval == 0) {
         _log.info("trips=" + tripIndex + " of " + trips.size());
       }
 

--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/GenerateNarrativesTask.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/GenerateNarrativesTask.java
@@ -100,8 +100,7 @@ public class GenerateNarrativesTask implements Runnable {
 
   private double _stopDirectionStandardDeviationThreshold = 0.7;
   
-  private LoggingIntervalUtil _logIntervals = new LoggingIntervalUtil();
-
+  
   @Autowired
   public void setBundle(FederatedTransitDataBundle bundle) {
     _bundle = bundle;
@@ -217,7 +216,7 @@ public class GenerateNarrativesTask implements Runnable {
     List<AgencyAndId> shapeIds = _gtfsDao.getAllShapeIds();
     int shapeSize = shapeIds.size();
     _log.info("shapes to process=" + shapeSize);
-    int logInterval = _logIntervals.getAppropriateLoggingInterval(shapeSize) * 10;
+    int logInterval = LoggingIntervalUtil.getAppropriateLoggingInterval(shapeSize) * 10;
     int index = 0;
 
     for (AgencyAndId shapeId : shapeIds) {
@@ -237,7 +236,7 @@ public class GenerateNarrativesTask implements Runnable {
 
     Collection<Stop> allStops = _gtfsDao.getAllStops();
     Map<AgencyAndId, Stop> stopsById = MappingLibrary.mapToValue(allStops, "id");
-    int logInterval = _logIntervals.getAppropriateLoggingInterval(allStops.size());
+    int logInterval = LoggingIntervalUtil.getAppropriateLoggingInterval(allStops.size());
 
     for (StopEntry stopEntry : _transitGraphDao.getAllStops()) {
 
@@ -265,7 +264,7 @@ public class GenerateNarrativesTask implements Runnable {
 
     int tripIndex = 0;
     Collection<Trip> trips = _gtfsDao.getAllTrips();
-    int logInterval = _logIntervals.getAppropriateLoggingInterval(trips.size());
+    int logInterval = LoggingIntervalUtil.getAppropriateLoggingInterval(trips.size());
 
     for (Trip trip : trips) {
 

--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/GtfsMultiReaderImpl.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/GtfsMultiReaderImpl.java
@@ -194,7 +194,7 @@ public class GtfsMultiReaderImpl implements Runnable {
       int c = _counter.getCount(key);
       if (c % logInterval == 0) {
 		  // backoff logging by power of ten
-    	  if (c == logInterval){
+    	  if (c == logInterval * 10){
     		  logInterval = logInterval * 10;
     		  System.out.println("now logging every " + logInterval);
     	  }

--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/GtfsMultiReaderImpl.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/GtfsMultiReaderImpl.java
@@ -178,6 +178,8 @@ public class GtfsMultiReaderImpl implements Runnable {
     private Counter<String> _counter = new Counter<String>();
 
     private Map<String, Long> _startTime = new HashMap<String, Long>();
+    
+    private int logInterval = 1000;
 
     public void handleEntity(Object bean) {
       String name = bean.getClass().getName();
@@ -190,7 +192,12 @@ public class GtfsMultiReaderImpl implements Runnable {
     private void increment(String key) {
       _counter.increment(key);
       int c = _counter.getCount(key);
-      if (c % 1000 == 0) {
+      if (c % logInterval == 0) {
+		  // backoff logging by power of ten
+    	  if (c == logInterval){
+    		  logInterval = logInterval * 10;
+    		  System.out.println("now logging every " + logInterval);
+    	  }
         double ellapsedTime = (System.currentTimeMillis() - getStartTimeForKey(key)) / 1000.0;
         System.out.println(key + " = " + c + " rate="
             + ((long) (c / ellapsedTime)));

--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/BlockEntriesFactory.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/BlockEntriesFactory.java
@@ -115,9 +115,8 @@ public class BlockEntriesFactory {
   private void processBlockTrips(TransitGraphImpl graph,
       Map<AgencyAndId, List<TripEntryImpl>> tripsByBlockId) {
 
-    int blockIndex = 0;
-    LoggingIntervalUtil _logIntervals = new LoggingIntervalUtil();
-	int logInterval = _logIntervals.getAppropriateLoggingInterval(tripsByBlockId.keySet().size());
+    int blockIndex = 0; 
+	int logInterval = LoggingIntervalUtil.getAppropriateLoggingInterval(tripsByBlockId.keySet().size());
 
     for (Map.Entry<AgencyAndId, List<TripEntryImpl>> entry : tripsByBlockId.entrySet()) {
 

--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/BlockEntriesFactory.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/BlockEntriesFactory.java
@@ -29,6 +29,7 @@ import org.onebusaway.gtfs.services.GtfsRelationalDao;
 import org.onebusaway.transit_data_federation.impl.transit_graph.BlockEntryImpl;
 import org.onebusaway.transit_data_federation.impl.transit_graph.TransitGraphImpl;
 import org.onebusaway.transit_data_federation.impl.transit_graph.TripEntryImpl;
+import org.onebusaway.transit_data_federation.util.LoggingIntervalUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -115,10 +116,12 @@ public class BlockEntriesFactory {
       Map<AgencyAndId, List<TripEntryImpl>> tripsByBlockId) {
 
     int blockIndex = 0;
+    LoggingIntervalUtil _logIntervals = new LoggingIntervalUtil();
+	int logInterval = _logIntervals.getAppropriateLoggingInterval(tripsByBlockId.keySet().size());
 
     for (Map.Entry<AgencyAndId, List<TripEntryImpl>> entry : tripsByBlockId.entrySet()) {
 
-      if (blockIndex % 10 == 0)
+      if (blockIndex % logInterval == 0)
         _log.info("block: " + blockIndex + "/" + tripsByBlockId.size());
       blockIndex++;
 

--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/FrequencyEntriesFactory.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/FrequencyEntriesFactory.java
@@ -60,8 +60,8 @@ public class FrequencyEntriesFactory {
     Map<AgencyAndId, List<FrequencyEntry>> frequenciesByTripId = new HashMap<AgencyAndId, List<FrequencyEntry>>();
 
     Collection<Frequency> allFrequencies = _gtfsDao.getAllFrequencies();
-    LoggingIntervalUtil _logIntervals = new LoggingIntervalUtil();
-	int logInterval = _logIntervals.getAppropriateLoggingInterval(allFrequencies.size());
+
+	int logInterval = LoggingIntervalUtil.getAppropriateLoggingInterval(allFrequencies.size());
 
     int frequencyIndex = 0;
     Map<AgencyAndId, Integer> exactTimesValueByTrip = new HashMap<AgencyAndId, Integer>();

--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/FrequencyEntriesFactory.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/FrequencyEntriesFactory.java
@@ -37,6 +37,7 @@ import org.onebusaway.transit_data_federation.services.transit_graph.BlockConfig
 import org.onebusaway.transit_data_federation.services.transit_graph.BlockTripEntry;
 import org.onebusaway.transit_data_federation.services.transit_graph.FrequencyEntry;
 import org.onebusaway.transit_data_federation.services.transit_graph.TripEntry;
+import org.onebusaway.transit_data_federation.util.LoggingIntervalUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,13 +60,15 @@ public class FrequencyEntriesFactory {
     Map<AgencyAndId, List<FrequencyEntry>> frequenciesByTripId = new HashMap<AgencyAndId, List<FrequencyEntry>>();
 
     Collection<Frequency> allFrequencies = _gtfsDao.getAllFrequencies();
+    LoggingIntervalUtil _logIntervals = new LoggingIntervalUtil();
+	int logInterval = _logIntervals.getAppropriateLoggingInterval(allFrequencies.size());
 
     int frequencyIndex = 0;
     Map<AgencyAndId, Integer> exactTimesValueByTrip = new HashMap<AgencyAndId, Integer>();
 
     for (Frequency frequency : allFrequencies) {
 
-      if (frequencyIndex % 100 == 0)
+      if (frequencyIndex % logInterval == 0)
         _log.info("frequencies: " + (frequencyIndex++) + "/"
             + allFrequencies.size());
       frequencyIndex++;

--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/RouteEntriesFactory.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/RouteEntriesFactory.java
@@ -49,14 +49,14 @@ public class RouteEntriesFactory {
 
   public void processRoutes(TransitGraphImpl graph) {
 
-    Collection<Route> routes = _gtfsDao.getAllRoutes();
-    LoggingIntervalUtil _logIntervals = new LoggingIntervalUtil();
-    int logInterval = _logIntervals.getAppropriateLoggingInterval(routes.size());
+    Collection<Route> routes = _gtfsDao.getAllRoutes(); 
+    int numRoutes = routes.size();
+    int logInterval = LoggingIntervalUtil.getAppropriateLoggingInterval(numRoutes);
     int routeIndex = 0;
 
     for (Route route : routes) {
     	if (routeIndex % logInterval == 0 ){
-    		_log.info("route processed: " + routeIndex + "/" + routes.size());
+    		_log.info("route processed: " + routeIndex + "/" + numRoutes);
     	}
       routeIndex++;
       processRoute(graph, route);

--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/RouteEntriesFactory.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/RouteEntriesFactory.java
@@ -22,6 +22,7 @@ import org.onebusaway.gtfs.services.GtfsRelationalDao;
 import org.onebusaway.transit_data_federation.bundle.services.UniqueService;
 import org.onebusaway.transit_data_federation.impl.transit_graph.RouteEntryImpl;
 import org.onebusaway.transit_data_federation.impl.transit_graph.TransitGraphImpl;
+import org.onebusaway.transit_data_federation.util.LoggingIntervalUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,10 +50,14 @@ public class RouteEntriesFactory {
   public void processRoutes(TransitGraphImpl graph) {
 
     Collection<Route> routes = _gtfsDao.getAllRoutes();
+    LoggingIntervalUtil _logIntervals = new LoggingIntervalUtil();
+    int logInterval = _logIntervals.getAppropriateLoggingInterval(routes.size());
     int routeIndex = 0;
 
     for (Route route : routes) {
-      _log.info("route processed: " + routeIndex + "/" + routes.size());
+    	if (routeIndex % logInterval == 0 ){
+    		_log.info("route processed: " + routeIndex + "/" + routes.size());
+    	}
       routeIndex++;
       processRoute(graph, route);
     }

--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/StopEntriesFactory.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/StopEntriesFactory.java
@@ -56,8 +56,7 @@ public class StopEntriesFactory {
     int stopIndex = 0;
 
     Collection<Stop> stops = _gtfsDao.getAllStops();
-    LoggingIntervalUtil _logIntervals = new LoggingIntervalUtil();
-    int logInterval = _logIntervals.getAppropriateLoggingInterval(stops.size());
+    int logInterval = LoggingIntervalUtil.getAppropriateLoggingInterval(stops.size());
     
     Map<String, ArrayList<StopEntry>> stopEntriesByAgencyId = new FactoryMap<String, ArrayList<StopEntry>>(
         new ArrayList<StopEntry>());

--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/StopEntriesFactory.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/StopEntriesFactory.java
@@ -28,6 +28,7 @@ import org.onebusaway.transit_data_federation.impl.transit_graph.AgencyEntryImpl
 import org.onebusaway.transit_data_federation.impl.transit_graph.StopEntryImpl;
 import org.onebusaway.transit_data_federation.impl.transit_graph.TransitGraphImpl;
 import org.onebusaway.transit_data_federation.services.transit_graph.StopEntry;
+import org.onebusaway.transit_data_federation.util.LoggingIntervalUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,12 +56,15 @@ public class StopEntriesFactory {
     int stopIndex = 0;
 
     Collection<Stop> stops = _gtfsDao.getAllStops();
+    LoggingIntervalUtil _logIntervals = new LoggingIntervalUtil();
+    int logInterval = _logIntervals.getAppropriateLoggingInterval(stops.size());
+    
     Map<String, ArrayList<StopEntry>> stopEntriesByAgencyId = new FactoryMap<String, ArrayList<StopEntry>>(
         new ArrayList<StopEntry>());
 
     for (Stop stop : stops) {
 
-      if (stopIndex % 500 == 0)
+      if (stopIndex % logInterval == 0)
         _log.info("stops: " + stopIndex + "/" + stops.size());
       stopIndex++;
 

--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/TripEntriesFactory.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/TripEntriesFactory.java
@@ -37,6 +37,7 @@ import org.onebusaway.transit_data_federation.impl.transit_graph.TripEntryImpl;
 import org.onebusaway.transit_data_federation.model.ShapePoints;
 import org.onebusaway.transit_data_federation.services.transit_graph.StopTimeEntry;
 import org.onebusaway.transit_data_federation.services.transit_graph.TripEntry;
+import org.onebusaway.transit_data_federation.util.LoggingIntervalUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -103,15 +104,19 @@ public class TripEntriesFactory {
       routeIndex++;
 
       List<Trip> tripsForRoute = _gtfsDao.getTripsForRoute(route);
+      
+      LoggingIntervalUtil _logIntervals = new LoggingIntervalUtil();
+      int tripCount = tripsForRoute.size();
+      int logInterval = _logIntervals.getAppropriateLoggingInterval(tripCount);
 
-      _log.info("trips to process: " + tripsForRoute.size());
+      _log.info("trips to process: " + tripCount);
       int tripIndex = 0;
       RouteEntryImpl routeEntry = graph.getRouteForId(route.getId());
       ArrayList<TripEntry> tripEntries = new ArrayList<TripEntry>();
 
       for (Trip trip : tripsForRoute) {
         tripIndex++;
-        if (tripIndex % 500 == 0)
+        if (tripIndex % logInterval == 0)
           _log.info("trips processed: " + tripIndex + "/"
               + tripsForRoute.size());
         TripEntryImpl tripEntry = processTrip(graph, trip);

--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/TripEntriesFactory.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/TripEntriesFactory.java
@@ -105,9 +105,8 @@ public class TripEntriesFactory {
 
       List<Trip> tripsForRoute = _gtfsDao.getTripsForRoute(route);
       
-      LoggingIntervalUtil _logIntervals = new LoggingIntervalUtil();
       int tripCount = tripsForRoute.size();
-      int logInterval = _logIntervals.getAppropriateLoggingInterval(tripCount);
+      int logInterval = LoggingIntervalUtil.getAppropriateLoggingInterval(tripCount);
 
       _log.info("trips to process: " + tripCount);
       int tripIndex = 0;

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/blocks/BlockIndexFactoryServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/blocks/BlockIndexFactoryServiceImpl.java
@@ -78,8 +78,6 @@ public class BlockIndexFactoryServiceImpl implements BlockIndexFactoryService {
 
   private static final Comparator<BlockSequence> _blockSequenceStrictComparator = new BlockTripStrictComparator<BlockSequence>();
   
-  private LoggingIntervalUtil _logIntervals = new LoggingIntervalUtil();
-
   private AgencyService _agencyService;
 
   private AgencyBeanService _agencyBeanService;
@@ -225,7 +223,7 @@ public class BlockIndexFactoryServiceImpl implements BlockIndexFactoryService {
   public List<BlockTripIndex> createTripIndices(Iterable<BlockEntry> blocks) {
 
     List<BlockTripIndex> allIndices = new ArrayList<BlockTripIndex>();
-    int logInterval = _logIntervals.getAppropriateLoggingInterval(allIndices.size());
+    int logInterval = LoggingIntervalUtil.getAppropriateLoggingInterval(allIndices.size());
 
     Map<BlockSequenceKey, List<BlockTripEntry>> blockTripsByKey = new FactoryMap<BlockSequenceKey, List<BlockTripEntry>>(
         new ArrayList<BlockTripEntry>());
@@ -285,7 +283,7 @@ public class BlockIndexFactoryServiceImpl implements BlockIndexFactoryService {
       Iterable<BlockEntry> blocks) {
 
     List<BlockLayoverIndex> allIndices = new ArrayList<BlockLayoverIndex>();
-    int logInterval = _logIntervals.getAppropriateLoggingInterval(allIndices.size());
+    int logInterval = LoggingIntervalUtil.getAppropriateLoggingInterval(allIndices.size());
 
     Map<BlockLayoverSequenceKey, List<BlockTripEntry>> blockTripsByServiceIds = new FactoryMap<BlockLayoverSequenceKey, List<BlockTripEntry>>(
         new ArrayList<BlockTripEntry>());
@@ -350,7 +348,7 @@ public class BlockIndexFactoryServiceImpl implements BlockIndexFactoryService {
       Iterable<BlockEntry> blocks) {
 
     List<FrequencyBlockTripIndex> allIndices = new ArrayList<FrequencyBlockTripIndex>();
-    int logInterval = _logIntervals.getAppropriateLoggingInterval(allIndices.size());
+    int logInterval = LoggingIntervalUtil.getAppropriateLoggingInterval(allIndices.size());
 
     Map<BlockSequenceKey, List<BlockTripEntry>> blockTripsByKey = new FactoryMap<BlockSequenceKey, List<BlockTripEntry>>(
         new ArrayList<BlockTripEntry>());

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/blocks/BlockIndexFactoryServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/blocks/BlockIndexFactoryServiceImpl.java
@@ -55,6 +55,7 @@ import org.onebusaway.transit_data_federation.services.transit_graph.HasBlockSto
 import org.onebusaway.transit_data_federation.services.transit_graph.StopEntry;
 import org.onebusaway.transit_data_federation.services.transit_graph.StopTimeEntry;
 import org.onebusaway.transit_data_federation.services.transit_graph.TripEntry;
+import org.onebusaway.transit_data_federation.util.LoggingIntervalUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -76,6 +77,8 @@ public class BlockIndexFactoryServiceImpl implements BlockIndexFactoryService {
   private static final Comparator<BlockSequence> _blockSequenceLooseComparator = new BlockStopTimeLooseComparator<BlockSequence>();
 
   private static final Comparator<BlockSequence> _blockSequenceStrictComparator = new BlockTripStrictComparator<BlockSequence>();
+  
+  private LoggingIntervalUtil _logIntervals = new LoggingIntervalUtil();
 
   private AgencyService _agencyService;
 
@@ -222,6 +225,7 @@ public class BlockIndexFactoryServiceImpl implements BlockIndexFactoryService {
   public List<BlockTripIndex> createTripIndices(Iterable<BlockEntry> blocks) {
 
     List<BlockTripIndex> allIndices = new ArrayList<BlockTripIndex>();
+    int logInterval = _logIntervals.getAppropriateLoggingInterval(allIndices.size());
 
     Map<BlockSequenceKey, List<BlockTripEntry>> blockTripsByKey = new FactoryMap<BlockSequenceKey, List<BlockTripEntry>>(
         new ArrayList<BlockTripEntry>());
@@ -259,7 +263,7 @@ public class BlockIndexFactoryServiceImpl implements BlockIndexFactoryService {
 
     for (List<BlockTripEntry> tripsWithSameSequence : blockTripsByKey.values()) {
 
-      if (_verbose && count % 100 == 0)
+      if (_verbose && count % logInterval == 0)
         _log.info("groups processed: " + count + "/" + blockTripsByKey.size());
 
       count++;
@@ -281,6 +285,7 @@ public class BlockIndexFactoryServiceImpl implements BlockIndexFactoryService {
       Iterable<BlockEntry> blocks) {
 
     List<BlockLayoverIndex> allIndices = new ArrayList<BlockLayoverIndex>();
+    int logInterval = _logIntervals.getAppropriateLoggingInterval(allIndices.size());
 
     Map<BlockLayoverSequenceKey, List<BlockTripEntry>> blockTripsByServiceIds = new FactoryMap<BlockLayoverSequenceKey, List<BlockTripEntry>>(
         new ArrayList<BlockTripEntry>());
@@ -324,7 +329,7 @@ public class BlockIndexFactoryServiceImpl implements BlockIndexFactoryService {
 
     for (List<BlockTripEntry> tripsWithSameSequence : blockTripsByServiceIds.values()) {
 
-      if (_verbose && count % 100 == 0)
+      if (_verbose && count % logInterval == 0)
         _log.info("groups processed: " + count + "/"
             + blockTripsByServiceIds.size());
 
@@ -345,6 +350,7 @@ public class BlockIndexFactoryServiceImpl implements BlockIndexFactoryService {
       Iterable<BlockEntry> blocks) {
 
     List<FrequencyBlockTripIndex> allIndices = new ArrayList<FrequencyBlockTripIndex>();
+    int logInterval = _logIntervals.getAppropriateLoggingInterval(allIndices.size());
 
     Map<BlockSequenceKey, List<BlockTripEntry>> blockTripsByKey = new FactoryMap<BlockSequenceKey, List<BlockTripEntry>>(
         new ArrayList<BlockTripEntry>());
@@ -381,7 +387,7 @@ public class BlockIndexFactoryServiceImpl implements BlockIndexFactoryService {
 
     for (List<BlockTripEntry> tripsWithSameSequence : blockTripsByKey.values()) {
 
-      if (_verbose && count % 100 == 0)
+      if (_verbose && count % logInterval == 0)
         _log.info("frequency groups processed: " + count + "/"
             + blockTripsByKey.size());
 

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/blocks/BlockStopTimeIndicesFactory.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/blocks/BlockStopTimeIndicesFactory.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.onebusaway.collections.FactoryMap;
 import org.onebusaway.gtfs.model.calendar.ServiceInterval;
+import org.onebusaway.transit_data_federation.util.LoggingIntervalUtil;
 import org.onebusaway.transit_data_federation.impl.transit_graph.FrequencyBlockStopTimeEntryImpl;
 import org.onebusaway.transit_data_federation.services.blocks.BlockIndexService;
 import org.onebusaway.transit_data_federation.services.blocks.BlockStopTimeIndex;
@@ -57,6 +58,8 @@ public class BlockStopTimeIndicesFactory {
   private static final FrequencyBlockStopTimeComparator _frequencyBlockStopTimeLooseComparator = new FrequencyBlockStopTimeComparator();
 
   private static final FrequencyBlockStopTimeStrictComparator _frequencyBlockStopTimeStrictComparator = new FrequencyBlockStopTimeStrictComparator();
+  
+  private LoggingIntervalUtil _logIntervals = new LoggingIntervalUtil();
 
   private boolean _verbose = false;
 
@@ -105,7 +108,7 @@ public class BlockStopTimeIndicesFactory {
       List<BlockConfigurationEntry> configurations = block.getConfigurations();
 
       if (configurations.isEmpty()) {
-        _log.warn("block has no active configurations: " + block.getId());
+        _log.warn("block is not referred to in calendars (no active configurations): " + block.getId());
         continue;
       }
 
@@ -152,12 +155,13 @@ public class BlockStopTimeIndicesFactory {
       Map<BlockStopTimeKey, List<BlockStopTimeEntry>> stopTimesByKey) {
 
     List<BlockStopTimeIndex> allIndices = new ArrayList<BlockStopTimeIndex>();
+    int logInterval = _logIntervals.getAppropriateLoggingInterval(allIndices.size()) * 10;
 
     int count = 0;
 
     for (List<BlockStopTimeEntry> stopTimes : stopTimesByKey.values()) {
 
-      if (_verbose && count % 1000 == 0)
+      if (_verbose && count % logInterval == 0)
         _log.info("groups processed: " + count + "/" + stopTimesByKey.size());
 
       count++;

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/blocks/BlockStopTimeIndicesFactory.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/blocks/BlockStopTimeIndicesFactory.java
@@ -59,8 +59,6 @@ public class BlockStopTimeIndicesFactory {
 
   private static final FrequencyBlockStopTimeStrictComparator _frequencyBlockStopTimeStrictComparator = new FrequencyBlockStopTimeStrictComparator();
   
-  private LoggingIntervalUtil _logIntervals = new LoggingIntervalUtil();
-
   private boolean _verbose = false;
 
   public void setVerbose(boolean verbose) {
@@ -155,7 +153,7 @@ public class BlockStopTimeIndicesFactory {
       Map<BlockStopTimeKey, List<BlockStopTimeEntry>> stopTimesByKey) {
 
     List<BlockStopTimeIndex> allIndices = new ArrayList<BlockStopTimeIndex>();
-    int logInterval = _logIntervals.getAppropriateLoggingInterval(allIndices.size()) * 10;
+    int logInterval = LoggingIntervalUtil.getAppropriateLoggingInterval(allIndices.size()) * 10;
 
     int count = 0;
 

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/util/LoggingIntervalUtil.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/util/LoggingIntervalUtil.java
@@ -7,10 +7,10 @@ public class LoggingIntervalUtil {
 		int interval = s/10;
 		// rounded to lowest power of 10. 
 		double exponent = Math.floor(Math.log10((double) interval));
-		double roundedInterval = Math.pow(10, exponent); 
+		int roundedInterval = (int) Math.pow(10, exponent); 
 		
 		if (roundedInterval >= 1) {
-			return (int) roundedInterval;
+			return roundedInterval;
 		}
 		else {
 			return 1;

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/util/LoggingIntervalUtil.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/util/LoggingIntervalUtil.java
@@ -4,13 +4,18 @@ public class LoggingIntervalUtil {
 	
 	public int getAppropriateLoggingInterval(int s){
 				
-		int interval = s/20;
+		int interval = s/10;
+		// rounded to lowest power of 10. 
+		double exponent = Math.floor(Math.log10((double) interval));
+		double roundedInterval = Math.pow(10, exponent); 
 		
-		if (interval > 0){
-			return interval;
-		} else {
+		if (roundedInterval > 0) {
+			return (int) roundedInterval;
+		}
+		else {
 			return 1;
 		}
+		
 	}
 
 }

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/util/LoggingIntervalUtil.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/util/LoggingIntervalUtil.java
@@ -2,7 +2,7 @@ package org.onebusaway.transit_data_federation.util;
 
 public class LoggingIntervalUtil {
 	
-	public int getAppropriateLoggingInterval(int s){
+	public static int getAppropriateLoggingInterval(int s){
 				
 		int interval = s/10;
 		// rounded to lowest power of 10. 

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/util/LoggingIntervalUtil.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/util/LoggingIntervalUtil.java
@@ -1,0 +1,16 @@
+package org.onebusaway.transit_data_federation.util;
+
+public class LoggingIntervalUtil {
+	
+	public int getAppropriateLoggingInterval(int s){
+				
+		int interval = s/20;
+		
+		if (interval > 0){
+			return interval;
+		} else {
+			return 1;
+		}
+	}
+
+}

--- a/onebusaway-transit-data-federation/src/test/java/org/onebusaway/transit_data_federation/util/LoggingIntervalUtilTest.java
+++ b/onebusaway-transit-data-federation/src/test/java/org/onebusaway/transit_data_federation/util/LoggingIntervalUtilTest.java
@@ -1,0 +1,17 @@
+package org.onebusaway.transit_data_federation.util;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class LoggingIntervalUtilTest {
+
+	@Test
+	public void test() {
+		LoggingIntervalUtil l = new LoggingIntervalUtil();
+		
+		assertEquals(Integer.valueOf(l.getAppropriateLoggingInterval(16777216)), Integer.valueOf(1000000));
+		assertEquals(Integer.valueOf(l.getAppropriateLoggingInterval(10)), Integer.valueOf(1));
+	}
+
+}

--- a/onebusaway-transit-data-federation/src/test/java/org/onebusaway/transit_data_federation/util/LoggingIntervalUtilTest.java
+++ b/onebusaway-transit-data-federation/src/test/java/org/onebusaway/transit_data_federation/util/LoggingIntervalUtilTest.java
@@ -8,11 +8,12 @@ public class LoggingIntervalUtilTest {
 
 	@Test
 	public void test() {
-		LoggingIntervalUtil l = new LoggingIntervalUtil();
-		
-		assertEquals(Integer.valueOf(l.getAppropriateLoggingInterval(16777216)), Integer.valueOf(1000000));
-		assertEquals(Integer.valueOf(l.getAppropriateLoggingInterval(10)), Integer.valueOf(1));
-		assertEquals(Integer.valueOf(l.getAppropriateLoggingInterval(-10)), Integer.valueOf(1));
+				
+		assertEquals(LoggingIntervalUtil.getAppropriateLoggingInterval(16777216), 1000000);
+		assertEquals(LoggingIntervalUtil.getAppropriateLoggingInterval(10), 1);
+		assertEquals(LoggingIntervalUtil.getAppropriateLoggingInterval(-10), 1);
+		assertEquals(LoggingIntervalUtil.getAppropriateLoggingInterval(Integer.MIN_VALUE), 1);
+		assertTrue(LoggingIntervalUtil.getAppropriateLoggingInterval(Integer.MAX_VALUE) > 1000000);
 	}
 
 }

--- a/onebusaway-transit-data-federation/src/test/java/org/onebusaway/transit_data_federation/util/LoggingIntervalUtilTest.java
+++ b/onebusaway-transit-data-federation/src/test/java/org/onebusaway/transit_data_federation/util/LoggingIntervalUtilTest.java
@@ -12,6 +12,7 @@ public class LoggingIntervalUtilTest {
 		
 		assertEquals(Integer.valueOf(l.getAppropriateLoggingInterval(16777216)), Integer.valueOf(1000000));
 		assertEquals(Integer.valueOf(l.getAppropriateLoggingInterval(10)), Integer.valueOf(1));
+		assertEquals(Integer.valueOf(l.getAppropriateLoggingInterval(-10)), Integer.valueOf(1));
 	}
 
 }


### PR DESCRIPTION
that were arbitrarily set to be chatty. This reduces the number of log messages by scaling the logging interval (in most cases) to a reasonable power of ten related to the size of the data being processed.

I'm assuming this would help with the Travis log file issue as well. 

Comments appreciated. 