### PR TITLE
Fixed unintended redirect to Flickr and a broken link

### DIFF
--- a/onebusaway-enterprise-acta-webapp/src/main/resources/onebusaway-enterprise.properties
+++ b/onebusaway-enterprise-acta-webapp/src/main/resources/onebusaway-enterprise.properties
@@ -44,6 +44,7 @@ main.agency.twitter.link=http://twitter.com
 main.agency.facebook.link=http://www.facebook.com
 main.agency.youtube.link=http://www.youtube.com
 main.agency.flickr.link=http://www.flickr.com
+main.privacypolicy.link=https://onebusaway.org/privacy/
 
 main.title=Onebusaway Enterprise
 main.agency.home=Home

--- a/onebusaway-enterprise-webapp/src/main/webapp/WEB-INF/decorators/main.jspx
+++ b/onebusaway-enterprise-webapp/src/main/webapp/WEB-INF/decorators/main.jspx
@@ -104,6 +104,7 @@
 	<div id="mainbox">
 		<div id="topbar">
 			<div id="branding">
+				<s:set var="link" value="getText('main.agency.link')" />
 				<a href="${link}">
 					<s:url var="url" value="css/img/agency_logo.png">
 						<s:param name="v">

--- a/onebusaway-enterprise-webapp/src/main/webapp/WEB-INF/decorators/where_main.jspx
+++ b/onebusaway-enterprise-webapp/src/main/webapp/WEB-INF/decorators/where_main.jspx
@@ -104,6 +104,7 @@
 	<div id="mainbox">
 		<div id="topbar">
 			<div id="branding">
+				<s:set var="link" value="getText('main.agency.link')" />
 				<a href="${link}">
 					<s:url var="url" value="../css/img/agency_logo.png">
 						<s:param name="v">

--- a/onebusaway-status-agent/pom.xml
+++ b/onebusaway-status-agent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>onebusaway-application-modules</artifactId>
         <groupId>org.onebusaway</groupId>
-        <version>2.0.2-cs-SNAPSHOT</version>
+        <version>2.0.3-cs-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>


### PR DESCRIPTION
Bug:       Clicking on the Logo redirects to Flickr
Cause:   Missing <s:set .../> tag meant to assign the logo image link
Fix:         Add missing tags where found

Note:      Added a missing link for the privacy policy.