### PR TITLE
Extending Service Filtering to Stop For Route

### DIFF
--- a/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/where/StopsForRouteAction.java
+++ b/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/where/StopsForRouteAction.java
@@ -19,8 +19,10 @@ import org.apache.struts2.rest.DefaultHttpHeaders;
 import org.onebusaway.api.actions.api.ApiActionSupport;
 import org.onebusaway.api.model.transit.BeanFactoryV2;
 import org.onebusaway.exceptions.ServiceException;
+import org.onebusaway.gtfs.model.calendar.ServiceDate;
 import org.onebusaway.transit_data.model.StopsForRouteBean;
 import org.onebusaway.transit_data.services.TransitDataService;
+import org.onebusaway.util.services.configuration.ConfigurationService;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.opensymphony.xwork2.validator.annotations.RequiredFieldValidator;
@@ -35,6 +37,9 @@ public class StopsForRouteAction extends ApiActionSupport {
 
   @Autowired
   private TransitDataService _service;
+
+  @Autowired
+  private ConfigurationService _configService;
 
   private String _id;
 
@@ -60,11 +65,15 @@ public class StopsForRouteAction extends ApiActionSupport {
 
 
   public DefaultHttpHeaders show() throws ServiceException {
-
     if (hasErrors())
       return setValidationErrorsResponse();
-
-    StopsForRouteBean result = _service.getStopsForRoute(_id);
+    boolean serviceDateFilterOn = Boolean.parseBoolean(_configService.getConfigurationValueAsString("display.serviceDateFiltering", "false"));
+    StopsForRouteBean result;
+    if (serviceDateFilterOn) {
+      result = _service.getStopsForRouteForServiceDate(_id, new ServiceDate());
+    } else {
+      result = _service.getStopsForRoute(_id);
+    }
 
     if (result == null)
       return setResourceNotFoundResponse();

--- a/onebusaway-status-agent/pom.xml
+++ b/onebusaway-status-agent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>onebusaway-application-modules</artifactId>
         <groupId>org.onebusaway</groupId>
-        <version>2.0.2-cs-SNAPSHOT</version>
+        <version>2.0.3-cs-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/onebusaway-status-agent/pom.xml
+++ b/onebusaway-status-agent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>onebusaway-application-modules</artifactId>
         <groupId>org.onebusaway</groupId>
-        <version>2.0.3-cs-SNAPSHOT</version>
+        <version>2.0.4-cs-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>


### PR DESCRIPTION
Bug: On the app, routes that had differing stops depending on the service date, were not displaying accurately. The stops were not being filtered by service date, as they were on the desktop version.

Cause: The app was hitting the stops-for-route API which was not applying the serviceDate filtering. 

Fix: Add the filtering functionality to the stop.

Note: I believe this is the only api in the module that was not filtering properly.