### PR TITLE
Toggle button in map legend

### DIFF
--- a/onebusaway-admin-webapp/src/main/webapp/js/oba/map/RouteMap.js
+++ b/onebusaway-admin-webapp/src/main/webapp/js/oba/map/RouteMap.js
@@ -449,6 +449,29 @@ OBA.RouteMap = function(mapNode, initCallbackFn, serviceAlertCallbackFn) {
         }
 
 
+		// create button
+		var toggle = document.createElement('button');
+		toggle.setAttribute('id', 'toggle_traffic');
+		toggle.innerHTML = "Traffic";
+
+		// create traffic overlay
+		var trafficLayer = new google.maps.TrafficLayer();
+		trafficLayer.setMap(map);
+
+		// click event listener
+		google.maps.event.addDomListener(toggle, 'click', function(){
+			// toggle 'setMap' between null and map
+			trafficLayer.setMap((trafficLayer.getMap()) ? null : map);
+		});
+
+		// wrap button in div, and append to map legend
+		var toggle_div = document.createElement('div');
+		toggle_div.appendChild(toggle);
+		legend.appendChild(toggle_div);
+
+
+
+
         map.controls[google.maps.ControlPosition.RIGHT_TOP].push(legend);
     }
 


### PR DESCRIPTION
Traffic overlay using google's default implementation.
Click event listener, using google.maps, to toggle this overlay on and off.
Using a button, in the map legend.

![Screen Shot 2019-05-13 at 10 44 00 AM](https://user-images.githubusercontent.com/25676106/57630693-145bf780-756c-11e9-84a2-43231d694916.png)
