### PR TITLE
Changes to links

### DIFF
--- a/onebusaway-enterprise-webapp/src/main/webapp/WEB-INF/content/index.jspx
+++ b/onebusaway-enterprise-webapp/src/main/webapp/WEB-INF/content/index.jspx
@@ -224,7 +224,7 @@
 			<div id="flexSpreader"><!-- jspx --></div>
 			<div class="container clear"><!-- jspx --></div>
 
-			<s:set var="link" value="getText('main.tools.link')" />
+			<s:set var="link" value="getText('main.apps.link')" />
 			<s:set var="mobile_image" value="getText('main.tools.mobile_image')" />
 			<a href="${link}">
 				<div id="mobileBox">

--- a/onebusaway-frontend-webapp/src/main/webapp/WEB-INF/decorators/mobile.jspx
+++ b/onebusaway-frontend-webapp/src/main/webapp/WEB-INF/decorators/mobile.jspx
@@ -73,7 +73,7 @@
     		<s:url var="contactUrl" namespace="/wiki" action="ContactUs"/>
     		<a href="${contactUrl}">Contact</a> |
 
-			<s:set var="link" value="getText('main.agency.link')" />
+			<s:set var="link" value="getText('main.agencysite.link')" />
 			<a href="${link}"><s:property value="getText('mobile.agency.name')" /></a>
 		</p>
 	</div>


### PR DESCRIPTION
OTD-227 Tools link should only be used to link to the tools wiki page
OTD-233 The agency link is being used as a home button, so main.agencysite.link is intended to go to the agencies website

Both require the most up to date sound-enterprise-webapp