### PR TITLE
Filtering monitored calls for skipped stops

### DIFF
--- a/onebusaway-presentation/src/main/java/org/onebusaway/presentation/impl/realtime/SiriSupport.java
+++ b/onebusaway-presentation/src/main/java/org/onebusaway/presentation/impl/realtime/SiriSupport.java
@@ -648,6 +648,11 @@ public final class SiriSupport {
 			predictedDepartureTime = prediction.getTimepointPredictedDepartureTime();
 		}
 
+		if (prediction != null && prediction.getScheduleRelationship() != null && prediction.isSkipped()) {
+			_log.info("SKIPPED STOP (MONITORED): " + stopBean.getId());
+			return null;
+		}
+
 		MonitoredCallStructure monitoredCallStructure = new MonitoredCallStructure();
 		monitoredCallStructure.setVisitNumber(BigInteger.valueOf(visitNumber));
 


### PR DESCRIPTION
In support of OTD-250
Both onward calls and monitored calls will not include predictions that are flagged as skipped.