### PR TITLE
Add confirm dialogue. User must click OK to confirm deletion.

### DIFF
--- a/onebusaway-admin-webapp/src/main/webapp/js/oba/service-alerts.js
+++ b/onebusaway-admin-webapp/src/main/webapp/js/oba/service-alerts.js
@@ -182,6 +182,9 @@ function onAddAnotherCondition() {
 	$("#conditionTable td:last.validateCondition").click(onValidateCondition);
 }
 function onDeleteCondition() {
+	if(!confirm("Are you sure you want to delete this condition?")){
+		return;
+	}
 	$(this).closest('tr').remove();
 	// Reset the name attributes for the remaining conditions to match their 
 	// new positions in the list.


### PR DESCRIPTION
This adds a confirm dialogue after the user clicks "Delete Condition" on the service alerts page of the admin app. Once prompted, the user can click OK or press enter to proceed with the deletion, or click Cancel or press escape to cancel and make no change.