### PR TITLE
Update to hide distance information for vehicles that are deadheading

### DIFF
--- a/onebusaway-frontend-webapp/src/main/webapp/js/oba/map/Popups.js
+++ b/onebusaway-frontend-webapp/src/main/webapp/js/oba/map/Popups.js
@@ -689,7 +689,12 @@ OBA.Popups = (function() {
 
                          if(typeof monitoredVehicleJourney.MonitoredCall !== 'undefined') {
 							 var loadOccupancy = getOccupancyForStop(monitoredVehicleJourney);
-                             var distance = monitoredVehicleJourney.MonitoredCall.Extensions.Distances.PresentableDistance + " " + loadOccupancy;
+							 var presentableDistance =  monitoredVehicleJourney.MonitoredCall.Extensions.Distances.PresentableDistance;
+							 if(presentableDistance !== undefined && typeof presentableDistance === 'string'){
+								 presentableDistance = presentableDistance.trim();
+							 }
+							 var hasPresentableDistance  = presentableDistance !== "";
+                             var distance = presentableDistance + " " + loadOccupancy;
 
 
                              var timePrediction = null;
@@ -750,7 +755,12 @@ OBA.Popups = (function() {
                                 timePrediction += ', ' + expectedTime;
                         	}
 							if(wrapped === false) {
-								timePrediction += ", " + distance;
+								if(hasPresentableDistance){
+									timePrediction += ", ";
+								} else {
+									timePrediction += " ";
+								}
+								 timePrediction += distance;
 							}
 							
 							var lastClass = ((_ === maxObservationsToShow - 1 || _ === mvjs.length - 1) ? " last" : "");

--- a/onebusaway-presentation/src/main/java/org/onebusaway/presentation/impl/realtime/PresentationServiceImpl.java
+++ b/onebusaway-presentation/src/main/java/org/onebusaway/presentation/impl/realtime/PresentationServiceImpl.java
@@ -17,6 +17,7 @@ package org.onebusaway.presentation.impl.realtime;
 
 import javax.annotation.PostConstruct;
 
+import org.apache.commons.lang.StringUtils;
 import org.onebusaway.container.ConfigurationParameter;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.presentation.services.realtime.PresentationService;
@@ -172,7 +173,10 @@ public class PresentationServiceImpl implements PresentationService {
   }
 
   @Override
-  public String getPresentableDistance(SiriDistanceExtension distances) {
+  public String getPresentableDistance(SiriDistanceExtension distances, String phase) {
+    if(isDeadHeading(phase)){
+      return " ";
+    }
     return getPresentableDistance(distances, APPROACHING_TEXT, ONE_STOP_WORD, MULTIPLE_STOPS_WORD, 
         ONE_MILE_WORD, MULTIPLE_MILES_WORD, AWAY_WORD);
   }
@@ -266,6 +270,13 @@ public class PresentationServiceImpl implements PresentationService {
     return r;
   }
 
+ private boolean isDeadHeading(String phase) {
+    if(phase != null){
+        return phase.toLowerCase().startsWith("deadhead");
+    }
+    return false;
+  }
+
   /**
    * Filter logic: these methods determine which buses are shown in different request contexts. By 
    * default, OBA reports all vehicles both scheduled and tracked, which one may or may not want.
@@ -310,7 +321,8 @@ public class PresentationServiceImpl implements PresentationService {
 	    if(phase != null 
 	        && !phase.toUpperCase().equals("IN_PROGRESS")
 	        && !phase.toUpperCase().equals("LAYOVER_BEFORE") 
-	        && !phase.toUpperCase().equals("LAYOVER_DURING")) {
+	        && !phase.toUpperCase().equals("LAYOVER_DURING")
+            && !phase.toUpperCase().equals("DEADHEAD_BEFORE")) {
 	      _log.debug("  " + statusBean.getVehicleId() + " filtered out because phase is not in progress.");      
 	      return false;
 	    }

--- a/onebusaway-presentation/src/main/java/org/onebusaway/presentation/impl/realtime/SiriSupport.java
+++ b/onebusaway-presentation/src/main/java/org/onebusaway/presentation/impl/realtime/SiriSupport.java
@@ -95,21 +95,32 @@ public final class SiriSupport {
 	 */
 	@SuppressWarnings("unused")
 	public static void fillMonitoredVehicleJourney(MonitoredVehicleJourneyStructure monitoredVehicleJourney,
-																																		 TripBean framedJourneyTripBean, ArrivalAndDepartureBean adBean,
-																																		 TripStatusBean currentVehicleTripStatus,
-																																		 StopBean monitoredCallStopBean, OnwardCallsMode onwardCallsMode,
-																																		 PresentationService presentationService, TransitDataService transitDataService,
-																																		 int maximumOnwardCalls, List<TimepointPredictionRecord> stopLevelPredictionsAcrossBlock,
-																																		 boolean hasRealtimeData, long responseTimestamp, boolean showRawLocation, boolean showApc) {
+												   TripBean framedJourneyTripBean,
+												   ArrivalAndDepartureBean adBean,
+												   TripStatusBean currentVehicleTripStatus,
+												   StopBean monitoredCallStopBean,
+												   OnwardCallsMode onwardCallsMode,
+												   PresentationService presentationService,
+												   TransitDataService transitDataService,
+												   int maximumOnwardCalls,
+												   List<TimepointPredictionRecord> stopLevelPredictionsAcrossBlock,
+												   boolean hasRealtimeData,
+												   long responseTimestamp,
+												   boolean showRawLocation,
+												   boolean showApc) {
 
-		if (currentVehicleTripStatus != null && TransitDataConstants.STATUS_CANCELED.equals(currentVehicleTripStatus.getStatus())) {
+		if (currentVehicleTripStatus != null
+			&& TransitDataConstants.STATUS_CANCELED.equals(currentVehicleTripStatus.getStatus())) {
 			_log.error("aborting fillMVJ as trip is canceled");
 			return;
 		}
 
 		BlockInstanceBean blockInstance = null;
 		if (adBean == null) {
-			blockInstance = transitDataService.getBlockInstance(currentVehicleTripStatus.getActiveTrip().getBlockId(), currentVehicleTripStatus.getServiceDate());
+			blockInstance = transitDataService.getBlockInstance(
+					currentVehicleTripStatus.getActiveTrip().getBlockId(),
+					currentVehicleTripStatus.getServiceDate());
+
 			if (blockInstance == null) {
 				_log.error("illegal blockId {}",  currentVehicleTripStatus.getActiveTrip().getBlockId());
 				return;
@@ -510,6 +521,7 @@ public final class SiriSupport {
 				} else {
 					blockTripStopsAfterTheVehicle++;
 				}
+
 				OnwardCallStructure ocs = getOnwardCallStructure(stop, presentationService,
 						distanceOfCallAlongTrip,
 						distanceOfVehicleFromCall,
@@ -518,7 +530,8 @@ public final class SiriSupport {
 						hasRealtimeData, responseTimestamp,
 						getScheduledArrivalTime(currentVehicleTripStatus.getServiceDate(), -1, stopTime),
 						getScheduledDepartureTime(currentVehicleTripStatus.getServiceDate(), -1, stopTime),
-						currentVehicleTripStatus.getScheduleDeviation());
+						currentVehicleTripStatus.getScheduleDeviation(),
+						currentVehicleTripStatus.getPhase());
 
 				if (ocs != null)
 					monitoredVehicleJourney.getOnwardCalls().getOnwardCall().add(ocs);
@@ -612,7 +625,8 @@ public final class SiriSupport {
 										responseTimestamp,
 										getScheduledArrivalTime(tripStatus.getServiceDate(), scheduledArrivalTime, stopTime),
 										getScheduledDepartureTime(tripStatus.getServiceDate(), scheduledDepartureTime, stopTime),
-										tripStatus.getScheduleDeviation());
+										tripStatus.getScheduleDeviation(),
+										tripStatus.getPhase());
 						if(msc != null)
 							monitoredVehicleJourney.setMonitoredCall(msc);
 					}
@@ -656,7 +670,7 @@ public final class SiriSupport {
 			PresentationService presentationService, 
 			double distanceOfCallAlongTrip, double distanceOfVehicleFromCall, int visitNumber, int index,
 			TimepointPredictionRecord prediction, boolean hasRealtimeData, long responseTimestamp,
-		    long scheduledArrivalTime, long scheduledDepartureTime, double scheduleDeviation) {
+		    long scheduledArrivalTime, long scheduledDepartureTime, double scheduleDeviation, String phase) {
 
 		boolean hasPrediction = prediction != null;
 		Long predictedArrivalTime = null;
@@ -720,10 +734,10 @@ public final class SiriSupport {
 		distances.setStopsFromCall(index);
 		distances.setCallDistanceAlongRoute(NumberUtils.toDouble(df.format(distanceOfCallAlongTrip)));
 		distances.setDistanceFromCall(NumberUtils.toDouble(df.format(distanceOfVehicleFromCall)));
-		distances.setPresentableDistance(presentationService.getPresentableDistance(distances));
+		distances.setPresentableDistance(presentationService.getPresentableDistance(distances, phase));
 
 		wrapper.setDistances(distances);
-		distancesExtensions.setAny(wrapper);    
+		distancesExtensions.setAny(wrapper);
 		onwardCallStructure.setExtensions(distancesExtensions);
 
 		return onwardCallStructure;
@@ -733,7 +747,7 @@ public final class SiriSupport {
 			PresentationService presentationService, 
 			double distanceOfCallAlongTrip, double distanceOfVehicleFromCall, int visitNumber, int index,
 			TimepointPredictionRecord prediction, boolean hasRealtimeData, long responseTimestamp,
-			long scheduledArrivalTime, long scheduledDepartureTime, double scheduleDeviation) {
+			long scheduledArrivalTime, long scheduledDepartureTime, double scheduleDeviation, String phase) {
 
 		boolean hasPrediction = prediction != null;
 		Long predictedArrivalTime = null;
@@ -777,7 +791,7 @@ public final class SiriSupport {
         if (monitoredCallStructure.getExpectedArrivalTime()!= null) {
             monitoredCallStructure.setAimedArrivalTime(new Date(scheduledArrivalTime));
         }
-
+		
 		// siri extensions
 		SiriExtensionWrapper wrapper = new SiriExtensionWrapper();
 		ExtensionsStructure distancesExtensions = new ExtensionsStructure();
@@ -789,8 +803,10 @@ public final class SiriSupport {
 
 		distances.setStopsFromCall(index);
 		distances.setCallDistanceAlongRoute(NumberUtils.toDouble(df.format(distanceOfCallAlongTrip)));
-		distances.setDistanceFromCall(NumberUtils.toDouble(df.format(distanceOfVehicleFromCall)));		
-		distances.setPresentableDistance(presentationService.getPresentableDistance(distances));
+		distances.setDistanceFromCall(NumberUtils.toDouble(df.format(distanceOfVehicleFromCall)));
+		distances.setPresentableDistance(presentationService.getPresentableDistance(distances, phase));
+
+		wrapper.setDistances(distances);
 
 		long deviation = 0L;
 		if (monitoredCallStructure.getExpectedArrivalTime() != null &&
@@ -802,7 +818,6 @@ public final class SiriSupport {
 		}
 
 		wrapper.setDeviation(String.valueOf(deviation));
-		wrapper.setDistances(distances);
 		distancesExtensions.setAny(wrapper);
 		monitoredCallStructure.setExtensions(distancesExtensions);
 
@@ -856,7 +871,6 @@ public final class SiriSupport {
 		}
 
 		if (phase.toLowerCase().startsWith("layover")
-				|| phase.toLowerCase().startsWith("deadhead")
 				|| phase.toLowerCase().equals("at_base")) {
 			return ProgressRateEnumeration.NO_PROGRESS;
 		}
@@ -865,7 +879,8 @@ public final class SiriSupport {
 			return ProgressRateEnumeration.NO_PROGRESS;
 		}
 
-		if (phase.toLowerCase().equals("in_progress")) {
+		if (phase.toLowerCase().equals("in_progress")
+			|| phase.toLowerCase().startsWith("deadhead")) {
 			return ProgressRateEnumeration.NORMAL_PROGRESS;
 		}
 

--- a/onebusaway-presentation/src/main/java/org/onebusaway/presentation/services/realtime/PresentationService.java
+++ b/onebusaway-presentation/src/main/java/org/onebusaway/presentation/services/realtime/PresentationService.java
@@ -33,7 +33,7 @@ public interface PresentationService {
       String approachingText, String oneStopWord, String multipleStopsWord,
       String oneMileWord, String multipleMilesWord, String awayWord);
 
-  public String getPresentableDistance(SiriDistanceExtension distances);
+  public String getPresentableDistance(SiriDistanceExtension distances, String phase);
 
   /* filter logic: */
 

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/BlockLocationServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/BlockLocationServiceImpl.java
@@ -24,6 +24,7 @@ import org.onebusaway.collections.Min;
 import org.onebusaway.collections.Range;
 import org.onebusaway.container.ConfigurationParameter;
 import org.onebusaway.gtfs.model.AgencyAndId;
+import org.onebusaway.realtime.api.EVehiclePhase;
 import org.onebusaway.realtime.api.EVehicleType;
 import org.onebusaway.realtime.api.TimepointPredictionRecord;
 import org.onebusaway.realtime.api.VehicleLocationRecord;
@@ -31,6 +32,7 @@ import org.onebusaway.transit_data_federation.model.TargetTime;
 import org.onebusaway.transit_data_federation.services.blocks.*;
 import org.onebusaway.transit_data_federation.services.realtime.*;
 import org.onebusaway.transit_data_federation.services.transit_graph.*;
+import org.onebusaway.util.EarthDistanceUtil;
 import org.onebusaway.util.SystemTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -131,6 +133,18 @@ public class BlockLocationServiceImpl extends AbstractBlockLocationServiceImpl i
    */
   private AtomicInteger _blockLocationRecordPersistentStoreAccessCount = new AtomicInteger();
 
+  /**
+   * Configuration to update the vehicle phase to "DEADHEAD_BEFORE" for vehicles
+   * traveling to the first stop on the black
+   */
+  private boolean _setPhaseToDeadBeforeAtStartOfBlock = false;
+
+  /**
+   * Configuration to set the minimum distance in feet at the start of the block
+   * to transition from "DEADHEAD_BEFORE" phase to "IN_PROGRESS"
+   */
+  private double _minBlockStopDistanceForDeadheadToInProgress = 100;
+
   @Autowired
   public void setVehicleLocationRecordCache(VehicleLocationRecordCache cache) {
     _cache = cache;
@@ -185,6 +199,16 @@ public class BlockLocationServiceImpl extends AbstractBlockLocationServiceImpl i
     _persistBlockLocationRecords = persistBlockLocationRecords;
   }
 
+  @ConfigurationParameter
+  public void setPhaseToDeadBeforeAtStartOfBlock(boolean setPhaseToDeadBeforeAtStartOfBlock) {
+    _setPhaseToDeadBeforeAtStartOfBlock = setPhaseToDeadBeforeAtStartOfBlock;
+  }
+
+  @ConfigurationParameter
+  public void setMinBlockStopDistanceForDeadheadToInProgress(double minBlockStopDistanceForDeadheadToInprogress) {
+    _minBlockStopDistanceForDeadheadToInProgress = minBlockStopDistanceForDeadheadToInprogress;
+  }
+
   /****
    * JMX Attributes
    ****/
@@ -230,14 +254,25 @@ public class BlockLocationServiceImpl extends AbstractBlockLocationServiceImpl i
     BlockInstance instance = getVehicleLocationRecordAsBlockInstance(record);
 
     if (instance != null) {
-
       ScheduledBlockLocation scheduledBlockLocation = getScheduledBlockLocationForVehicleLocationRecord(
               record, instance);
-
 
       if (!record.isScheduleDeviationSet() && scheduledBlockLocation != null ) {
         int deviation = (int) ((record.getTimeOfRecord() - record.getServiceDate()) / 1000 - scheduledBlockLocation.getScheduledTime());
         record.setScheduleDeviation(deviation);
+      }
+
+      if(_setPhaseToDeadBeforeAtStartOfBlock
+              && record.isCurrentLocationSet()
+              && scheduledBlockLocation != null
+              && scheduledBlockLocation.getStopTimeIndex() == 0){
+
+        double distance = EarthDistanceUtil.distanceInMeters(record.getCurrentLocationLat(), record.getCurrentLocationLon(),
+                scheduledBlockLocation.getLocation().getLat(), scheduledBlockLocation.getLocation().getLon());
+
+        if(distance >= _minBlockStopDistanceForDeadheadToInProgress) {
+          record.setPhase(EVehiclePhase.DEADHEAD_BEFORE);
+        }
       }
 
       ScheduleDeviationSamples samples = null;

--- a/onebusaway-util/src/main/java/org/onebusaway/util/EarthDistanceUtil.java
+++ b/onebusaway-util/src/main/java/org/onebusaway/util/EarthDistanceUtil.java
@@ -1,0 +1,55 @@
+package org.onebusaway.util;
+
+public class EarthDistanceUtil {
+
+    private static final double EARTH_RADIUS_KM = 6371;
+
+    public static double distanceInKilometers(double lat1, double lon1, double lat2, double lon2) {
+        return computeDistanceKm(lat1, lon1, lat2, lon2, DistanceUnit.KILOMETERS);
+    }
+
+    public static double distanceInMeters(double lat1, double lon1, double lat2, double lon2) {
+        return computeDistanceKm(lat1, lon1, lat2, lon2, DistanceUnit.METERS);
+    }
+
+    public static double distanceInMiles(double lat1, double lon1, double lat2, double lon2) {
+        return computeDistanceKm(lat1, lon1, lat2, lon2, DistanceUnit.MILES);
+    }
+
+    public static double distanceInFeet(double lat1, double lon1, double lat2, double lon2) {
+        return computeDistanceKm(lat1, lon1, lat2, lon2, DistanceUnit.FEET);
+    }
+
+    private static double computeDistanceKm(double lat1, double lon1, double lat2, double lon2, DistanceUnit unit) {
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+        double rLat1 = Math.toRadians(lat1);
+        double rLat2 = Math.toRadians(lat2);
+
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(rLat1) * Math.cos(rLat2)
+                * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        double distanceKm = EARTH_RADIUS_KM * c;
+
+        return unit.fromKilometers(distanceKm);
+    }
+
+    public enum DistanceUnit {
+        KILOMETERS(1.0),
+        METERS(1000.0),
+        MILES(0.621371),
+        FEET(3280.8399);
+
+        private final double kmMultiplier;
+
+        DistanceUnit(double kmMultiplier) {
+            this.kmMultiplier = kmMultiplier;
+        }
+
+        public double fromKilometers(double km) {
+            return km * kmMultiplier;
+        }
+    }
+
+}


### PR DESCRIPTION
OneBusAway does not accurately show distance away when a vehicle is deadheading at the start of a block. This fix hides vehicle distance until the bus is some configurable distance away.