### PR TITLE
Obanyc/unified/feature/obanyc 4053 build and replace stop times from the original trip modifications

### DIFF
--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_tripmodifications/GtfsTripModificationsClientImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_tripmodifications/GtfsTripModificationsClientImpl.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.transit.realtime.GtfsRealtime.Shape;
 import com.google.transit.realtime.GtfsRealtime.Stop;
 
+import org.onebusaway.transit_data_federation.impl.realtime.gtfs_tripmodifications.service.GtfsTripModificationsHandler;
 import org.onebusaway.transit_data_federation.impl.realtime.gtfs_tripmodifications.service.ShapeHandler;
 import org.onebusaway.transit_data_federation.impl.realtime.gtfs_tripmodifications.service.StopHandler;
+import org.onebusaway.transit_data_federation.impl.realtime.gtfs_tripmodifications.service.TripModsTripChangeHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,6 +39,8 @@ public class GtfsTripModificationsClientImpl implements GtfsTripModificationsCli
 
     private ShapeHandler _shapeHandler;
 
+    private GtfsTripModificationsHandler _gtfsTripModificationsHandler;
+
     private int _refreshInterval;
 
     private ObjectMapper _mapper = new ObjectMapper();
@@ -59,6 +63,11 @@ public class GtfsTripModificationsClientImpl implements GtfsTripModificationsCli
     @Autowired
     public void setShapeHandler(ShapeHandler shapeHandler) {
         _shapeHandler = shapeHandler;
+    }
+
+    @Autowired
+    public void setGtfsTripModificationsHandler(GtfsTripModificationsHandler gtfsTripModificationsHandler) {
+        _gtfsTripModificationsHandler = gtfsTripModificationsHandler;
     }
 
     @Autowired
@@ -170,10 +179,9 @@ public class GtfsTripModificationsClientImpl implements GtfsTripModificationsCli
         int numberOfSuccessfullyAddedStops = _stopHandler.addStops(stopsList).size();
         _log.info("Stops: processed {} stops, corresponding to {} successful new stop additions", totalStops, numberOfSuccessfullyAddedStops);
         int numberOfSuccessfullyAddedShapes = _shapeHandler.addShapes(shapesList).size();
-        _log.info("Shapes: processed {} shapes, corresponding to {} successful internal changes", totalShapes, numberOfSuccessfullyAddedShapes);
-        int success = 0;
-//        success = _gtfsTripModificationsHandler.handleTripModifications(feedMessage.getHeader().getTimestamp(), tripModificationsList);
-        _log.info("Service changes: processed {} service changes, corresponding to {} successful internal changes", totalMods, success);
+        _log.info("Shapes: processed {} shapes, corresponding to {} successful new shape additions", totalShapes, numberOfSuccessfullyAddedShapes);
+        int successfulTripChanges = _gtfsTripModificationsHandler.handleTripModifications(feedMessage.getHeader().getTimestamp(), tripModificationsList);
+        _log.info("Trip changes: processed {} trip changes, corresponding to {} successful internal changes", totalMods, successfulTripChanges);
     }
 
 

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_tripmodifications/impl/GtfsTripModificationsHandlerImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_tripmodifications/impl/GtfsTripModificationsHandlerImpl.java
@@ -1,0 +1,229 @@
+package org.onebusaway.transit_data_federation.impl.realtime.gtfs_tripmodifications.impl;
+
+import com.google.transit.realtime.GtfsRealtime.TripModifications;
+import org.onebusaway.container.cache.CacheableMethodManager;
+import org.onebusaway.container.refresh.RefreshService;
+import org.onebusaway.transit_data_federation.impl.RefreshableResources;
+import org.onebusaway.transit_data_federation.impl.realtime.gtfs_sometimes.model.ShapeChangeSet;
+import org.onebusaway.transit_data_federation.impl.realtime.gtfs_sometimes.model.StopChangeSet;
+import org.onebusaway.transit_data_federation.impl.realtime.gtfs_sometimes.model.TripChange;
+import org.onebusaway.transit_data_federation.impl.realtime.gtfs_sometimes.model.TripChangeSet;
+import org.onebusaway.transit_data_federation.impl.realtime.gtfs_sometimes.service.TimeService;
+import org.onebusaway.transit_data_federation.impl.realtime.gtfs_tripmodifications.service.TripModsTripChangeHandler;
+import org.onebusaway.transit_data_federation.impl.realtime.gtfs_tripmodifications.service.GtfsTripModificationsHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class GtfsTripModificationsHandlerImpl implements GtfsTripModificationsHandler {
+    private static final Logger _log = LoggerFactory.getLogger(GtfsTripModificationsHandlerImpl.class);
+
+    private long _lastUpdatedTimestamp = -1;
+
+    private TimeService _timeService;
+
+    private LocalDateTime _reapplyTime;
+
+    private RefreshService _refreshService;
+
+    private CacheableMethodManager _cacheableMethodManager;
+
+    private CacheableMethodManager _cacheableAnnotationInterceptor;
+
+    private TripModsTripChangeHandler _tripChangeHandler;
+
+    private TripChangeSet revertTripChanges;
+
+    private boolean _isApplying = false;
+
+    @Autowired
+    public void setRefreshService(RefreshService refreshService) {
+        _refreshService = refreshService;
+    }
+
+    @Autowired
+    @Qualifier("cacheableMethodManager")
+    public void setCacheableMethodManager(CacheableMethodManager cacheableMethodManager) {
+        _cacheableMethodManager = cacheableMethodManager;
+    }
+
+    @Autowired
+    @Qualifier("cacheableAnnotationInterceptor")
+    public void setCacheableAnnotationInterceptor(CacheableMethodManager cacheableAnnotationInterceptor) {
+        _cacheableAnnotationInterceptor = cacheableAnnotationInterceptor;
+    }
+
+    @Autowired
+    public void setTripModsTripChangeHandler(TripModsTripChangeHandler tripChangeHandler) {
+        _tripChangeHandler = tripChangeHandler;
+    }
+
+    @Autowired
+    public void setTimeService(TimeService timeService) {
+        _timeService = timeService;
+    }
+
+    @Override
+    public int handleTripModifications(long timestamp, Collection<TripModifications> tripModificationsList) {
+
+        // Check whether changes should be re-applied
+        if (!shouldApplyChanges(timestamp, tripModificationsList)) {
+            _log.info("Not applying changes.");
+            return 0;
+        }
+
+        _isApplying = true;
+
+        //TODO implement revert changes
+        int nReverted = 0; //revertPreviousChanges();
+
+        List<TripModifications> activeChanges = filterModifications(tripModificationsList);
+
+        int nSuccess = 0;
+
+        for (TripModifications tm : activeChanges) {
+            _log.info("Active TripModification: {}", tm);
+
+
+            TripChangeSet tripChanges = _tripChangeHandler.getAllTripChanges(tm);
+
+            revertTripChanges = _tripChangeHandler.applyChanges(tripChanges);
+
+            nSuccess += revertTripChanges.size();
+            if (nSuccess > 0 || nReverted > 0) {
+                forceFlush();
+            }
+            _isApplying = false;
+
+            _lastUpdatedTimestamp = timestamp;
+            _reapplyTime = getReapplyTime(tripChanges.getAllChanges());
+
+            _log.info("Done with changes. Total internal changes: {}. Total reverted changes: {}. " +
+                    "Reapply time is {}, last updated is {}", nSuccess, nReverted, _reapplyTime, _lastUpdatedTimestamp);
+
+
+        }
+
+        return nSuccess;
+
+    }
+
+//    int revertPreviousChanges() {
+//        int nTotal = 0;
+//        //TODO fix shapes
+////        if (revertShapeChanges != null) {
+////            int success = _shapeChangeHandler.handleShapeChanges(revertShapeChanges).size();
+////            if (success != revertShapeChanges.size()) {
+////                _log.error("Error reverting some shapes!");
+////            }
+////            nTotal += success;
+////        }
+//        if (revertStopChanges != null) {
+//            int success = _stopChangeHandler.handleStopChanges(revertStopChanges).size();
+//            if (success != revertStopChanges.size()) {
+//                _log.error("Error reverting some stops!");
+//            }
+//            nTotal += success;
+//        }
+//        if (revertTripChanges != null) {
+//            int success = _tripChangeHandler.handleTripChanges(revertTripChanges).size();
+//            if (success != revertTripChanges.size()) {
+//                _log.error("Error reverting some trips!");
+//            }
+//            nTotal += success;
+//        }
+//        return nTotal;
+//    }
+
+    boolean shouldApplyChanges(long timestamp, Collection<TripModifications> tripModifications) {
+        if (_lastUpdatedTimestamp == -1) {
+            _log.info("First update for feed.");
+            if (tripModifications.isEmpty()) {
+                _log.info("Feed is empty, ignoring.");
+                return false;
+            }
+            return true;
+        } else if (_lastUpdatedTimestamp < timestamp) {
+            _log.info("Update feed.");
+            return true;
+        } else if (_lastUpdatedTimestamp == timestamp) {
+            _log.info("Feed is the same as previously processed, check reapply time ({}), current time = {}",
+                    _reapplyTime, _timeService.getCurrentTime());
+            return _timeService.getCurrentTime().isAfter(_reapplyTime);
+        } else {
+            _log.error("Non-increasing timestamps in feed!");
+            return false;
+        }
+    }
+
+    List<TripModifications> filterModifications(Collection<TripModifications>  tripModificationsList) {
+        return tripModificationsList.stream().filter(this::isTripModificationOk).collect(Collectors.toList());
+    }
+
+    boolean isTripModificationOk(TripModifications tripModifications) {
+        if (!validateModifications(tripModifications)) {
+            _log.debug("service change is invalid");
+            return false;
+        }
+        return true;
+    }
+
+    private boolean validateModifications(TripModifications tripModifications) {
+        if (tripModifications.getServiceDatesList().isEmpty()) {
+            _log.info("affected dates is empty");
+            //TODO change this to false- keeping it as true for now to allow testing with existing data
+            return true;
+        }
+        //TODO - not sure if this is applicable for TripModifications
+//        switch(change.getServiceChangeType()) {
+//            case ADD:
+//                return change.getAffectedEntity().isEmpty() && !change.getAffectedField().isEmpty();
+//            case ALTER:
+//                return !change.getAffectedEntity().isEmpty() && change.getAffectedField().size() == 1;
+//            case DELETE:
+//                return !change.getAffectedEntity().isEmpty() && change.getAffectedField().isEmpty();
+//        }
+//        return false;
+        return true;
+    }
+
+    // Re-apply time is earliest of: midnight tonight, or (future) end time of a trip that begins on the previous service day.
+    LocalDateTime getReapplyTime(List<TripChange> tripChanges) {
+        LocalDate today = _timeService.getCurrentDate();
+        LocalDateTime now = _timeService.getCurrentTime();
+        LocalDateTime reapplyTime = today.atStartOfDay().plusDays(1); // midnight tonight
+        for (TripChange tripChange : tripChanges) {
+            if (tripChange.getServiceDate().isBefore(today)) {
+                LocalDateTime endTime = tripChange.getEndTime();
+                if (endTime.isAfter(now) && endTime.isBefore(reapplyTime)) {
+                    reapplyTime = endTime;
+                }
+            }
+        }
+        return reapplyTime;
+    }
+
+    void forceFlush() {
+        _refreshService.refresh(RefreshableResources.BLOCK_INDEX_DATA_GRAPH);
+        try {
+            if (_cacheableMethodManager != null) {
+                _cacheableMethodManager.flush();
+            }
+            if (_cacheableAnnotationInterceptor != null) {
+                _cacheableAnnotationInterceptor.flush();
+            }
+        } catch (Throwable t) {
+            _log.error("issue flushing cache:", t);
+        }
+    }
+
+}

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_tripmodifications/impl/GtfsTripModsServiceChangeLibrary.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_tripmodifications/impl/GtfsTripModsServiceChangeLibrary.java
@@ -1,0 +1,51 @@
+package org.onebusaway.transit_data_federation.impl.realtime.gtfs_tripmodifications.impl;
+
+import com.camsys.transit.servicechange.DateDescriptor;
+import org.onebusaway.gtfs.model.calendar.ServiceDate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+public class GtfsTripModsServiceChangeLibrary {
+    private static Logger _log = LoggerFactory.getLogger(org.onebusaway.transit_data_federation.impl.realtime.gtfs_tripmodifications.impl.GtfsTripModsServiceChangeLibrary.class);
+
+    static boolean dateIsApplicable(LocalDate date, List<DateDescriptor> serviceDates) {
+        for (DateDescriptor dateDescriptor : serviceDates) {
+            if (dateDescriptor.getDate() != null && dateDescriptor.getDate().isEqual(date)) {
+                return true;
+            }
+            if (dateDescriptor.getFrom() != null) {
+                if (dateDescriptor.getTo() != null) {
+                    LocalDate from = dateDescriptor.getFrom();
+                    LocalDate to = dateDescriptor.getTo();
+                    if ((date.isEqual(from) || date.isAfter(from)) && (date.isEqual(to) || date.isBefore(to))) {
+                        return true;
+                    }
+                } else {
+                    LocalDate from = dateDescriptor.getFrom();
+                    if ((date.isEqual(from) || date.isAfter(from))) {
+                        return true;
+                    }
+                }
+            } else if (dateDescriptor.getTo() != null) {
+                _log.error("Not supported: to-date with no from-date specified.");
+            }
+        }
+        return false;
+    }
+
+    static LocalDate toLocalDate(long epochTime, ZoneId timeZone) {
+        return Instant.ofEpochMilli(epochTime).atZone(timeZone).toLocalDate();
+    }
+
+    static ServiceDate toServiceDate(LocalDate date) {
+        int year = date.getYear();
+        int month = date.getMonthValue();
+        int day = date.getDayOfMonth();
+        return new ServiceDate(year, month, day);
+    }
+}

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_tripmodifications/impl/TripModsTripChangeHandlerImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_tripmodifications/impl/TripModsTripChangeHandlerImpl.java
@@ -1,0 +1,351 @@
+package org.onebusaway.transit_data_federation.impl.realtime.gtfs_tripmodifications.impl;
+
+import com.camsys.transit.servicechange.DateDescriptor;
+import com.camsys.transit.servicechange.EntityDescriptor;
+import com.camsys.transit.servicechange.ServiceChange;
+import com.camsys.transit.servicechange.field_descriptors.StopTimesFields;
+import com.camsys.transit.servicechange.field_descriptors.TripsFields;
+import com.google.transit.realtime.GtfsRealtime.ReplacementStop;
+import com.google.transit.realtime.GtfsRealtime.TripModifications;
+import com.google.transit.realtime.GtfsRealtime.StopSelector;
+import com.google.transit.realtime.GtfsRealtime.TripModifications.SelectedTrips;
+import com.google.transit.realtime.GtfsRealtime.TripModifications.Modification;
+import org.onebusaway.container.cache.CacheableMethodManager;
+import org.onebusaway.container.refresh.RefreshService;
+import org.onebusaway.gtfs.model.AgencyAndId;
+import org.onebusaway.gtfs.model.Trip;
+import org.onebusaway.gtfs.model.calendar.LocalizedServiceId;
+import org.onebusaway.gtfs.model.calendar.ServiceDate;
+import org.onebusaway.gtfs.services.calendar.CalendarService;
+import org.onebusaway.transit_data_federation.impl.RefreshableResources;
+import org.onebusaway.transit_data_federation.impl.realtime.gtfs_sometimes.model.*;
+import org.onebusaway.transit_data_federation.impl.realtime.gtfs_sometimes.service.TimeService;
+import org.onebusaway.transit_data_federation.impl.realtime.gtfs_tripmodifications.service.TripModsTripChangeHandler;
+import org.onebusaway.transit_data_federation.impl.transit_graph.BlockEntryImpl;
+import org.onebusaway.transit_data_federation.impl.transit_graph.RouteEntryImpl;
+import org.onebusaway.transit_data_federation.impl.transit_graph.StopEntryImpl;
+import org.onebusaway.transit_data_federation.impl.transit_graph.StopTimeEntryImpl;
+import org.onebusaway.transit_data_federation.impl.transit_graph.TripEntryImpl;
+import org.onebusaway.transit_data_federation.model.StopTimeInstance;
+import org.onebusaway.transit_data_federation.model.narrative.RouteCollectionNarrative;
+import org.onebusaway.transit_data_federation.model.narrative.StopNarrative;
+import org.onebusaway.transit_data_federation.model.narrative.TripNarrative;
+import org.onebusaway.transit_data_federation.services.EntityIdService;
+import org.onebusaway.transit_data_federation.services.StopTimeService;
+import org.onebusaway.transit_data_federation.services.blocks.BlockCalendarService;
+import org.onebusaway.transit_data_federation.services.blocks.BlockInstance;
+import org.onebusaway.transit_data_federation.services.narrative.NarrativeService;
+import org.onebusaway.transit_data_federation.services.transit_graph.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import org.onebusaway.transit_data_federation.impl.realtime.gtfs_tripmodifications.impl.GtfsTripModsServiceChangeLibrary.*;
+
+import static org.onebusaway.transit_data_federation.impl.realtime.gtfs_tripmodifications.impl.GtfsTripModsServiceChangeLibrary.*;
+
+@Component
+public class TripModsTripChangeHandlerImpl implements TripModsTripChangeHandler {
+
+    private static final Logger _log = LoggerFactory.getLogger(org.onebusaway.transit_data_federation.impl.realtime.gtfs_sometimes.impl.TripChangeHandlerImpl.class);
+
+    private TransitGraphDao _dao;
+
+    private EntityIdService _entityIdService;
+
+    private NarrativeService _narrativeService;
+
+    private StopTimeService _stopTimeService;
+
+    private TimeService _timeService;
+
+    private BlockCalendarService _blockCalendarService;
+
+    private CalendarService _calendarService;
+
+    private TripChangeSet revertTripChanges;
+
+    private RefreshService _refreshService;
+
+    private CacheableMethodManager _cacheableMethodManager;
+
+    private CacheableMethodManager _cacheableAnnotationInterceptor;
+
+    private boolean _isApplying = false;
+
+    private DateTimeFormatter SERVICE_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
+    //TODO what is the service date format
+
+    @Autowired
+    public void setRefreshService(RefreshService refreshService) {
+        _refreshService = refreshService;
+    }
+    @Autowired
+    @Qualifier("cacheableMethodManager")
+    public void setCacheableMethodManager(CacheableMethodManager cacheableMethodManager) {
+        _cacheableMethodManager = cacheableMethodManager;
+    }
+
+    @Autowired
+    @Qualifier("cacheableAnnotationInterceptor")
+    public void setCacheableAnnotationInterceptor(CacheableMethodManager cacheableAnnotationInterceptor) {
+        _cacheableAnnotationInterceptor = cacheableAnnotationInterceptor;
+    }
+
+    @Autowired
+    public void setTransitGraphDao(TransitGraphDao dao) {
+        _dao = dao;
+    }
+
+    @Autowired
+    public void setEntityIdService(EntityIdService entityIdService) {
+        _entityIdService = entityIdService;
+    }
+
+    @Autowired
+    public void setNarrativeService(NarrativeService narrativeService) {
+        _narrativeService = narrativeService;
+    }
+
+    @Autowired
+    public void setStopTimeService(StopTimeService stopTimeService) {
+        _stopTimeService = stopTimeService;
+    }
+
+    @Autowired
+    public void setTimeService(TimeService timeService) {
+        _timeService = timeService;
+    }
+
+    @Autowired
+    public void setBlockCalendarService(BlockCalendarService blockCalendarService) {
+        _blockCalendarService = blockCalendarService;
+    }
+
+    @Autowired
+    public void setCalendarService(CalendarService calendarService) {
+        _calendarService = calendarService;
+    }
+
+    @Override
+    public TripChangeSet getAllTripChanges(TripModifications tripModifications) {
+        TripChangeSet changeSet = new TripChangeSet();
+
+        List<LocalDate> serviceDates = parseServiceDates(tripModifications.getServiceDatesList());
+        List<Modification> modifications = tripModifications.getModificationsList();
+
+        for (SelectedTrips selectedTrips : tripModifications.getSelectedTripsList()) {
+            String shapeId = selectedTrips.hasShapeId() ? selectedTrips.getShapeId() : null;
+
+            for (String tripId : selectedTrips.getTripIdsList()) {
+                String agencyId = _entityIdService.getTripId(tripId).getAgencyId();
+                AgencyAndId agencyTripId = new AgencyAndId(agencyId, tripId);
+                AgencyAndId agencyShapeId = shapeId != null ? new AgencyAndId(agencyId, shapeId) : null;
+
+                for (LocalDate serviceDate : serviceDates) {
+                    TripChange change = createModifyTrip(
+                            agencyTripId,
+                            agencyShapeId,
+                            serviceDate,
+                            modifications
+                    );
+
+                    changeSet.addModifiedTrip((ModifyTrip) change);
+                }
+            }
+        }
+
+        return changeSet;
+    }
+
+    private ModifyTrip createModifyTrip(AgencyAndId tripId,
+                                        AgencyAndId shapeId,
+                                        LocalDate serviceDate,
+                                        List<Modification> modifications) {
+        ModifyTrip modifyTrip = new ModifyTrip();
+        modifyTrip.setTripId(tripId);
+        modifyTrip.setShapeId(shapeId);
+        modifyTrip.setServiceDate(serviceDate);
+
+        TripEntryImpl tripEntry = (TripEntryImpl) _dao.getTripEntryForId(tripId);
+        modifyTrip.setTripEntry(tripEntry);
+
+        List<StopTimeEntry> modifiedStopTimes = buildModifiedStopTimes(tripEntry, modifications);
+        modifyTrip.setStopTimes(modifiedStopTimes);
+
+        return modifyTrip;
+    }
+
+    private List<StopTimeEntry> buildModifiedStopTimes(TripEntryImpl originalTrip,
+                                                       List<Modification> modifications) {
+        List<StopTimeEntry> result = new ArrayList<>();
+        List<StopTimeEntry> originalStopTimes = originalTrip.getStopTimes();
+
+        for (Modification mod : modifications) {
+            int startIndex = findStopIndex(originalStopTimes, mod.getStartStopSelector());
+            int endIndex = findStopIndex(originalStopTimes, mod.getEndStopSelector());
+
+            for (int i = 0; i < startIndex; i++) {
+                result.add(originalStopTimes.get(i));
+            }
+
+            int referenceTime = getReferenceTime(originalStopTimes, startIndex);
+            for (var replacementStop : mod.getReplacementStopsList()) {
+                StopTimeEntry newStopTime = createStopTimeEntry(
+                        replacementStop,
+                        referenceTime,
+                        result.size() + 1
+                );
+                result.add(newStopTime);
+            }
+
+            for (int i = endIndex + 1; i < originalStopTimes.size(); i++) {
+                StopTimeEntry adjusted = adjustStopTime(
+                        originalStopTimes.get(i),
+                        result.size() + 1,
+                        mod.getPropagatedModificationDelay()
+                );
+                result.add(adjusted);
+            }
+        }
+
+        return result;
+    }
+
+    private int getReferenceTime(List<StopTimeEntry> stopTimes, int startIndex) {
+        if (startIndex > 0) {
+            return stopTimes.get(startIndex - 1).getArrivalTime();
+        }
+        return stopTimes.get(0).getArrivalTime();
+    }
+
+    private StopTimeEntry createStopTimeEntry(ReplacementStop replacementStop,
+                                              int referenceTime,
+                                              int stopSequence) {
+        String stopId = replacementStop.getStopId();
+
+        Double lat = null;
+        Double lon = null;
+        String stopName = null; //TODO not needed?
+
+        StopEntry se = _dao.getStopEntryForId(AgencyAndId.convertFromString(stopId));
+        if (se == null) {
+            throw new IllegalArgumentException("Stop entry not found for id: " + stopId);
+        }
+        StopNarrative sn = _narrativeService.getStopForId(se.getId());
+        if (sn == null) {
+            throw new IllegalArgumentException("Stop narrative not found for id: " + stopId);
+        }
+
+        lat = se.getStopLat();
+        lon = se.getStopLon();
+        stopName = _narrativeService.getStopForId(se.getId()).getName();
+
+        // Calculate arrival time
+        int arrivalTime = referenceTime;
+        if (replacementStop.hasTravelTimeToStop()) {
+            arrivalTime = referenceTime + replacementStop.getTravelTimeToStop();
+        }
+
+        // Build your StopTimeEntry - adjust to match your actual class
+        StopTimeEntryImpl entry = new StopTimeEntryImpl();
+        entry.setSequence(stopSequence);
+        entry.setArrivalTime(arrivalTime);
+        entry.setDepartureTime(arrivalTime);  // departure = arrival per spec
+        StopEntryImpl stopEntry = new StopEntryImpl(_entityIdService.getStopId(stopId),lat,lon);
+        entry.setStop(stopEntry);
+
+        return entry;
+    }
+
+    private int findStopIndex(List<StopTimeEntry> stopTimes, StopSelector selector) {
+        if (selector.hasStopSequence()) {
+            int seq = selector.getStopSequence();
+            for (int i = 0; i < stopTimes.size(); i++) {
+                if (stopTimes.get(i).getSequence() == seq) {
+                    return i;
+                }
+            }
+        } else if (selector.hasStopId()) {
+            String stopId = selector.getStopId();
+            for (int i = 0; i < stopTimes.size(); i++) {
+                if (stopTimes.get(i).getStop().getId().getId().equals(stopId)) {
+                    return i;
+                }
+            }
+        }
+        throw new IllegalArgumentException("Stop not found for selector: " + selector);
+    }
+
+    private StopTimeEntry adjustStopTime(StopTimeEntry original,
+                                         int newSequence,
+                                         int propagatedDelay) {
+        StopTimeEntryImpl adjusted = new StopTimeEntryImpl(original);
+        adjusted.setSequence(newSequence);
+        adjusted.setArrivalTime(original.getArrivalTime() + propagatedDelay);
+        adjusted.setDepartureTime(original.getDepartureTime() + propagatedDelay);
+        return adjusted;
+    }
+
+    private List<LocalDate> parseServiceDates(List<String> serviceDateStrings) {
+        return serviceDateStrings.stream()
+                .map(s -> LocalDate.parse(s, SERVICE_DATE_FORMAT))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public TripChangeSet applyChanges(TripChangeSet changeset) {
+        TripChangeSet revertSet = new TripChangeSet();
+        for (AddTrip addTrip : changeset.getAddedTrips()) {
+            _log.info("Handling changes for trip {}", addTrip.getTripId());
+            if (_dao.addTripEntry(addTrip.getTripEntry(), addTrip.getTripNarrative())) {
+                DeleteTrip deleteTrip = new DeleteTrip(addTrip.getTripId(), addTrip.getServiceDate(), addTrip.getEndTime());
+                revertSet.addDeletedTrip(deleteTrip);
+            } else {
+                _log.info("Unable to apply changes for trip {}", addTrip.getTripId());
+            }
+        }
+        for (ModifyTrip modifyTrip : changeset.getModifiedTrips()) {
+            _log.info("Handling changes for trip {}", modifyTrip.getTripId());
+            ModifyTrip revertTrip = getModifyTripForExistingTrip(modifyTrip.getTripId());
+            if (_dao.updateStopTimesForTrip(modifyTrip.getTripEntry(), modifyTrip.getStopTimes(), modifyTrip.getShapeId())) {
+                revertSet.addModifiedTrip(revertTrip);
+            } else {
+                _log.info("Unable to apply changes for trip {}", modifyTrip.getTripId());
+            }
+        }
+        return revertSet;
+    }
+
+    private ModifyTrip getModifyTripForExistingTrip(AgencyAndId tripId) {
+        TripEntryImpl tripEntry = (TripEntryImpl) _dao.getTripEntryForId(tripId);
+        ModifyTrip modify = new ModifyTrip();
+        modify.setTripId(tripId);
+        modify.setShapeId(tripEntry.getShapeId());
+        modify.setStopTimes(tripEntry.getStopTimes());
+        modify.setTripEntry(tripEntry);
+        modify.setServiceDate(getServiceDateForTrip(tripEntry));
+        return modify;
+    }
+
+    // Note: If current time is 3pm, and a block ends at 1pm: it's next service date is tomorrow.
+    // This has implications for block consistency.
+    private LocalDate getServiceDateForTrip(TripEntry trip) {
+        long now = _timeService.getCurrentTimeAsEpochMs();
+        List<BlockInstance> blocks = _blockCalendarService.getActiveBlocks(trip.getBlock().getId(), now, now + (24 * 3600 * 1000));
+        if (blocks.isEmpty())
+            return null;
+        // Get BlockInstance which is active with minimum service date
+        BlockInstance block = Collections.min(blocks, Comparator.comparingLong(BlockInstance::getServiceDate));
+        return toLocalDate(block.getServiceDate(), _timeService.getTimeZone());
+    }
+}

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_tripmodifications/service/GtfsTripModificationsHandler.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_tripmodifications/service/GtfsTripModificationsHandler.java
@@ -1,0 +1,16 @@
+package org.onebusaway.transit_data_federation.impl.realtime.gtfs_tripmodifications.service;
+
+import com.google.transit.realtime.GtfsRealtime.TripModifications;
+
+import java.util.Collection;
+
+public interface GtfsTripModificationsHandler {
+
+    /**
+     * Process TripModifications; make the appropriate changes in the graph.
+     *
+     * @param tripModifications to process
+     * @return number of tripmodification fully successfully handled
+     */
+    int handleTripModifications(long timestamp, Collection<TripModifications> tripModifications);
+}

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_tripmodifications/service/TripModsTripChangeHandler.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_tripmodifications/service/TripModsTripChangeHandler.java
@@ -1,0 +1,18 @@
+package org.onebusaway.transit_data_federation.impl.realtime.gtfs_tripmodifications.service;
+
+import com.google.transit.realtime.GtfsRealtime;
+import com.google.transit.realtime.GtfsRealtime.TripModifications;
+import org.onebusaway.transit_data_federation.impl.realtime.gtfs_sometimes.model.TripChangeSet;
+
+public interface TripModsTripChangeHandler {
+
+    /**
+     * Get all trip changes from a TripModifications message
+     *
+     * @param tripModifications to process
+     * @return all trip changes
+     */
+    TripChangeSet getAllTripChanges(TripModifications tripModifications);
+
+    TripChangeSet handleTripChanges(TripChangeSet tripChangeSet);
+}

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_tripmodifications/service/TripModsTripChangeHandler.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_tripmodifications/service/TripModsTripChangeHandler.java
@@ -1,8 +1,11 @@
 package org.onebusaway.transit_data_federation.impl.realtime.gtfs_tripmodifications.service;
 
+import com.camsys.transit.servicechange.ServiceChange;
 import com.google.transit.realtime.GtfsRealtime;
 import com.google.transit.realtime.GtfsRealtime.TripModifications;
 import org.onebusaway.transit_data_federation.impl.realtime.gtfs_sometimes.model.TripChangeSet;
+
+import java.util.Collection;
 
 public interface TripModsTripChangeHandler {
 
@@ -14,5 +17,11 @@ public interface TripModsTripChangeHandler {
      */
     TripChangeSet getAllTripChanges(TripModifications tripModifications);
 
-    TripChangeSet handleTripChanges(TripChangeSet tripChangeSet);
+    /**
+     * Apply trip changes to the graph
+     *
+     * @param tripChangeSet to apply
+     * @return the applied tripChangeSet
+     */
+    TripChangeSet applyChanges(TripChangeSet tripChangeSet);
 }


### PR DESCRIPTION
### OBANYC-4053: Build and Replace Stop Times from TripModifications

- Implements dynamically modifying trip stop times in the transit graph
- Builds modified stop time sequences by:
  - Inserting replacement stops with calculated arrival/departure times
  - Adjusting subsequent stops with propagated delay

**Notes**

- Revert functionality is stubbed but not fully implemented (marked with TODO)
- Validation currently allows empty service dates for testing compatibility