### PR TITLE
[OBANYC-4053] shape id fixes

### DIFF
--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/beans/RouteBeanServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/beans/RouteBeanServiceImpl.java
@@ -136,7 +136,7 @@ class RouteBeanServiceImpl implements RouteBeanService {
   @Autowired
   public void setExtCalendarService(ExtendedCalendarService extCalendarService) { _extCalendarService = extCalendarService; }
 
-  @Cacheable
+
   public RouteBean getRouteForId(AgencyAndId id) {
     RouteCollectionNarrative rc = _narrativeService.getRouteCollectionForId(id);
     if (rc == null)
@@ -144,7 +144,7 @@ class RouteBeanServiceImpl implements RouteBeanService {
     return getRouteBeanForRouteCollection(id, rc);
   }
 
-  @Cacheable
+
   public StopsForRouteBean getStopsForRoute(AgencyAndId routeId) {
     RouteCollectionEntry routeCollectionEntry = _transitGraphDao.getRouteCollectionForId(routeId);
     RouteCollectionNarrative narrative = _narrativeService.getRouteCollectionForId(routeId);
@@ -154,7 +154,7 @@ class RouteBeanServiceImpl implements RouteBeanService {
         narrative, null);
   }
 
-  @Cacheable
+
   public StopsForRouteBean getStopsForRouteForServiceDate(AgencyAndId routeId, ServiceDate serviceDate) {
     RouteCollectionEntry routeCollectionEntry = _transitGraphDao.getRouteCollectionForId(routeId);
     RouteCollectionNarrative narrative = _narrativeService.getRouteCollectionForId(routeId);

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/beans/ShapeBeanServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/beans/ShapeBeanServiceImpl.java
@@ -58,7 +58,7 @@ class ShapeBeanServiceImpl implements ShapeBeanService {
     _transitGraphDao = transitGraphDao;
   }
 
-  @Cacheable
+
   public EncodedPolylineBean getPolylineForShapeId(AgencyAndId id) {
     ShapePoints shapePoints = _shapePointService.getShapePointsForShapeId(id);
     if (shapePoints == null)
@@ -67,7 +67,7 @@ class ShapeBeanServiceImpl implements ShapeBeanService {
         shapePoints.getLons(), -1);
   }
 
-  @Cacheable
+
   public List<EncodedPolylineBean> getMergedPolylinesForShapeIds(
       Collection<AgencyAndId> shapeIds) {
 

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_tripmodifications/impl/ShapeHandlerImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_tripmodifications/impl/ShapeHandlerImpl.java
@@ -87,8 +87,9 @@ public class ShapeHandlerImpl implements ShapeHandler {
             ShapePoints sp = new ShapePoints();
             sp.setLats(lat);
             sp.setLons(lon);
-            sp.ensureDistTraveled();
             sp.setShapeId(shapeId);
+            sp.setDistTraveled(new double[coordinatePointsList.size()]);
+            sp.ensureDistTraveled();
             _dao.addShape(sp);
 
             successfullyAddedShapes.add(sp);


### PR DESCRIPTION
`Cacheable` annotations were removed, but this maybe is not a good long term fix. Should flush the cache when new disruptions are processed.

**NOTE**

`DistanceAlongShapeLibrary.java` has an `assignmentSanityCheck` method that might discard shapes if they are illogical so this might need to be disabled when testing weird "test only" shapes 